### PR TITLE
Fix payload written to influxdb

### DIFF
--- a/v1/src/lib.rs
+++ b/v1/src/lib.rs
@@ -443,7 +443,7 @@ impl Storage for InfluxDbStorage {
         // encode the value as a string to be stored in InfluxDB, converting to base64 if the buffer is not a UTF-8 string
         let (base64, strvalue) = match payload.try_to_string() {
             Ok(s) => (false, s),
-            Err(err) => (true, b64_std_engine.encode(err.to_string()).into()),
+            Err(err) => (true, b64_std_engine.encode(payload.to_bytes()).into()),
         };
 
         // Note: tags are stored as strings in InfluxDB, while fileds are typed.


### PR DESCRIPTION
Fixes writing binary data to influxdb, as it was it was writing the error message produced trying to parse binary as utf-8